### PR TITLE
Functions to create projects using ODK Central API

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A utility to manage data from Open Data Kit's [ODK Central aggregation server](https://docs.getodk.org/central-intro/), particularly for use with [OpenDroneMap](opendronemap.org) (ODM).
 
+It uses the [ODK Central API](https://odkcentral.docs.apiary.io).
+
 ODK Central provides a Web interface to manage forms, submissions, and media (photos etc). However, when faced with hundreds of GB of media, the Web interface can be tricky. Specifically, if a lot of media is submittted to a single form, ODK Central's Web interface only provides methods to download a single file at a time, or _the entire set_ as a zipfile&mdash;the former is time-consuming, and the latter is prone to failed downloads.
 
 To create a [3DStreetView](3dstreetview.org) digital twin, users routinely gather thousands of photographs per day. If multiple users are submitting to the same form, it almost immediately becomes difficult to access the media on the server.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # odk2odm
 
-A utility to manage data from Open Data Kit's ODK Central aggregation server, particularly for use with [OpenDroneMap](opendronemap.org) (ODM).
+A utility to manage data from Open Data Kit's [ODK Central aggregation server](https://docs.getodk.org/central-intro/), particularly for use with [OpenDroneMap](opendronemap.org) (ODM).
 
 ODK Central provides a Web interface to manage forms, submissions, and media (photos etc). However, when faced with hundreds of GB of media, the Web interface can be tricky. Specifically, if a lot of media is submittted to a single form, ODK Central's Web interface only provides methods to download a single file at a time, or _the entire set_ as a zipfile&mdash;the former is time-consuming, and the latter is prone to failed downloads.
 
@@ -24,7 +24,35 @@ From there, you can:
 - Get a list of attachment filenames in a specific submission
 - Download any attachment by filename
 
-These functions are all contained in the ```fetch.py``` module. The ```attachments.py``` utility uses the functions in ```fetch.py``` to download all of the attachments in all submissions to a given form from the command line, like so:
+The actual working functions are all contained in the ```fetch.py``` module. These are functions that return replies from an ODK Central server. 
+
+These functions mostly return [requests.Response() objects](https://www.w3schools.com/python/ref_requests_response.asp). These objects contains status code of the request (200, 404, etc), and the data itself, as well as a number of other attributes.
+
+The base_url parameter is just the URL of the ODK Central server. The extra characters needed to actually reach the API ('/v1/') are built into the functions.
+
+The aut parameter is a tuple of the username and password used to authenticate the requester on the server, in the form (username, password). The passwords are in plain text; ideally this should be a hash but I haven't gotten around to that.
+
+Simple usage:
+If you want to see if a server is working and you are able to reach it, use the ```projects``` function:
+
+```
+url = 'https://3dstreetview.org'
+aut = ('myusername', 'mypassword')
+r = fetch.projects(url, aut)
+r.status_code
+```
+
+If all went well, that'll return '200'. If you got the username/password wrong (or aren't authorized on the server for whatever reason) it'll return '401', or '404' if the server isn't found at all.
+
+To see the data: ```r.json()```. That'll return a JSON-formatted string with information about the projects on the server.
+
+To see the information on a single project: ```r.json()[0]```. That'll return a dictionary with the attributes of the first project on the server.
+
+To see the name of the first project: ```r.json()[0]['name']``` 
+
+### Downloading lots of attachments
+
+The ```attachments.py``` utility uses the functions in ```fetch.py``` to download all of the attachments in all submissions to a given form from the command line, like so:
 
 ```
 python3 attachments.py -url https://myodkcentral.org -u myusername@email.com -pw mypassword -p 3 -f my_form_v2-1-4 -od /home/myself/centraldata

--- a/attachments.py
+++ b/attachments.py
@@ -39,6 +39,7 @@ def all_attachments_from_form(url, aut, project, form, outdir):
 
 def specified_attachments_from_form(url, aut, project, form, outdir, infile):
     """Downloads attachments specified in a text file."""
+    # TODO: COMPLETE
     wantedfiles = []
     try:
         inputfile = open(infile)

--- a/fetch.py
+++ b/fetch.py
@@ -90,9 +90,7 @@ def attachment(base_url, aut, projectId, formId, instanceId, filename):
 def create_project(base_url, aut, project_name):
     """Create a new project on an ODK Central server"""
     url = f'{base_url}/v1/projects'
-    namedict = {'name': project_name}
-    postbody = json.dumps(namedict, indent = 2)
-    return requests.post(url, auth = aut, data = postbody)
+    return requests.post(url, auth = aut, json = {'name': project_name})
 
 def delete_project(base_url, aut, project_id):
     """Permanently delete project from an ODK Central server. Probably don't."""

--- a/fetch.py
+++ b/fetch.py
@@ -41,6 +41,7 @@ r.json()[0]['name']
 
 import sys, os
 import requests
+import json
 
 def projects(base_url, aut):
     """Fetch a list of projects on an ODK Central server."""
@@ -85,3 +86,15 @@ def attachment(base_url, aut, projectId, formId, instanceId, filename):
     url = f'{base_url}/v1/projects/{projectId}/forms/{formId}/submissions/'\
         f'{instanceId}/attachments/{filename}'
     return requests.get(url, auth = aut)
+
+def create_project(base_url, aut, project_name):
+    """Create a new project on an ODK Central server"""
+    url = f'{base_url}/v1/projects'
+    namedict = {'name': project_name}
+    postbody = json.dumps(namedict, indent = 2)
+    return requests.post(url, auth = aut, data = postbody)
+
+def delete_project(base_url, aut, project_id):
+    """Permanently delete project from an ODK Central server. Probably don't."""
+    url = f'{base_url}/v1/projects/{project_id}'
+    return requests.delete(url, auth = aut)

--- a/fetch.py
+++ b/fetch.py
@@ -1,4 +1,43 @@
 #!/usr/bin/python3
+"""Utilities for interacting with ODK Central API
+
+These are functions that return replies from an ODK Central server. https://docs.getodk.org/central-intro/
+
+These functions mostly return requests.Response() objects. That object contains status code of the request (200, 404, etc), and the data itself, as well as a number of other attributes.
+
+Here's a great reference on how to use the returned objects: https://www.w3schools.com/python/ref_requests_response.asp
+
+The base_url parameter is just the URL of the ODK Central server. The extra characters needed to actually reach the API ('/v1/') are built into the functions.
+
+The aut parameter is a tuple of the username and password used to authenticate the requester on the server, in the form (username, password). The passwords are in plain text; ideally this should be a hash but I haven't gotten around to that.
+
+Simple usage:
+If you want to see if a server is working and you are able to reach it, use the projects function:
+
+url = 'https://3dstreetview.org'
+aut = ('myusername', 'mypassword')
+r = fetch.projects(url, aut)
+r.status_code
+
+If all went well, that'll return '200'. If you got the username/password wrong (or aren't authorized on the server for whatever reason) it'll return '401', or '404' if the server isn't found at all.
+
+To see the data:
+
+r.json()
+
+That'll return a JSON-formatted string with information about the projects on the server.
+
+To see the information on a single project:
+
+r.json()[0]
+
+That'll return a dictionary with the attributes of the first project on the server.
+
+To see the name of the first project:
+
+r.json()[0]['name']
+ 
+"""
 
 import sys, os
 import requests
@@ -18,7 +57,8 @@ def submissions(base_url, aut, projectId, formId):
     url = f'{base_url}/v1/projects/{projectId}/forms/{formId}/submissions'
     return requests.get(url, auth = aut)
 
-# Should work with ?media=false appended but doesn't. Use the odata version.
+# Should work with ?media=false appended but doesn't.
+# Probabaly a bug in ODK Central. Use the odata version; it works.
 def csv_submissions(base_url, aut, projectId, formId):
     """Fetch a CSV file of the submissions to a survey form."""
     f'{base_url}/v1/projects/{projectId}/forms/{formId}/submissions.csv.zip'
@@ -45,10 +85,3 @@ def attachment(base_url, aut, projectId, formId, instanceId, filename):
     url = f'{base_url}/v1/projects/{projectId}/forms/{formId}/submissions/'\
         f'{instanceId}/attachments/{filename}'
     return requests.get(url, auth = aut)
-
-if __name__ == '__main__':
-    pass
-
-    
-
-    


### PR DESCRIPTION
Added functions to ```fetch.py``` that enable the creation and deletion of projects on arbitrary ODK Central servers (at least for people with proper credentials on that server). This should make it straightforward to build a web dashboard where users can create a project for a new 3DStreetView mesh. 

Also added quite a bit of detail in the docstrings and readme on how to use the functions in fetch.py (including, at Hessel's request, instructions to fetch the response codes to check if a server is present, responding, and if the user is authenticated. 